### PR TITLE
Suggestion to strike "3 days" in favor of "a date"

### DIFF
--- a/we_use_consensus_to_make_decisions.md
+++ b/we_use_consensus_to_make_decisions.md
@@ -32,9 +32,9 @@ or rejected.
 A proposal is **approved** when it has received 0 and +1 votes from all members of
 the team.
 
-A proposal is **approved** when it has received only votes of 0 or +1 for 3 days
-even if not every member has voted. This is a "lazy consensus" approval. Lazy
-consensus approvals should be announced in the `#platform_engineering_team`
+A proposal should include a date at which point it can be **approved** as long
+as it has received only votes of 0 or +1. This is a "lazy consensus" approval.
+Lazy consensus approvals should be announced in the `#platform_engineering_team`
 Slack channel with a link to the original proposal thread.
 
 A -1 from any member on a proposal is a veto. If a proposal has an -1 votes it


### PR DESCRIPTION
My thinking is, what if we settle on 2 days? Do we make a new ADR amending this one? I'd rather that detail be left to convention and group norms, maybe to be discussed in retrospectives, but not really in scope for the decision to adopt lazy consensus.

This way, there's a date, and it's part of the proposal.